### PR TITLE
Add default S3 Managed encryption

### DIFF
--- a/cloud_templates/aws_cdk/KinesisPattern/kinesis_pattern/kinesis_pattern_stack.py
+++ b/cloud_templates/aws_cdk/KinesisPattern/kinesis_pattern/kinesis_pattern_stack.py
@@ -50,7 +50,7 @@ class KinesisPatternStack(Stack):
         self.performInputValidation()
 
         # Create a bucket for as delivery stream's destination 
-        bucket = s3.Bucket(self, self.kinesis_destination_bucket_name, versioned=True, removal_policy=cdk.RemovalPolicy.DESTROY, auto_delete_objects=True)
+        bucket = s3.Bucket(self, self.kinesis_destination_bucket_name, versioned=True, removal_policy=cdk.RemovalPolicy.DESTROY, auto_delete_objects=True, encryption=s3.BucketEncryption.S3_MANAGED)
 
         # Creating a role for the delivery stream 
         firehose_role = iam.Role(self, self.kinesis_delivery_stream_role_name, assumed_by=iam.ServicePrincipal("firehose.amazonaws.com"))

--- a/cloud_templates/demo/demo_templates/kinesis_pattern.json
+++ b/cloud_templates/demo/demo_templates/kinesis_pattern.json
@@ -11,6 +11,15 @@
     ],
     "VersioningConfiguration": {
      "Status": "Enabled"
+    },
+    "BucketEncryption" : {
+        "ServerSideEncryptionConfiguration" : [
+            {
+                "ServerSideEncryptionByDefault" : {
+                    "SSEAlgorithm" : "AES256"
+                }
+            }
+        ]
     }
    },
    "UpdateReplacePolicy": "Delete",

--- a/cloud_templates/user_guides/kinesis_guide.md
+++ b/cloud_templates/user_guides/kinesis_guide.md
@@ -62,7 +62,7 @@ If you are interested in using the CloudFormation templates more than just for d
 2. Run `python -m pip install -r requirements.txt` and `python -m pip install -r requirements.txt` to install the dependencies.
 3. Go through the `README.md` file to learn about the context parameters that need to be set by you prior to deployment.
 4. Set the context parameter values either by changing `cdk.json` file or by using the command line.
-    1. To create a command line context variable, use the **`—-context (-c) option`**, as shown in the following example: `$ cdk cdk synth -c bucket_name=mybucket`
+    1. To create a command line context variable, use the **`—-context (-c) option`**, as shown in the following example: `$ cdk synth -c bucket_name=mybucket`
     2. To specify the same context variable and value in the `cdk.json` file, use the following code.`
           {"context": { "bucket_name": "mybucket"}`
 5. Run `cdk synth` to emit the synthesized CloudFormation template.


### PR DESCRIPTION
Description
-----------
Adds default S3 managed encryption (using AES256)
to the kenesis json and CDK files. Corrects cdk command in user guide.

I've tested by deploying both through CDK and the CloudFormation json template.
The CDK deployment was successful.
The JSON template fails as S3 items  haven't been created. However this S3 bucket itself is created, which is enough for my change. This change also wouldn't affect bucket item creation.

Doc links:
* https://docs.aws.amazon.com/AmazonS3/latest/userguide/serv-side-encryption.html
* https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-s3-bucket-serversideencryptionbydefault.html

Checklist:
----------
- [x] I have tested my changes. No regression in existing tests.
- [x] My code is Linted.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.